### PR TITLE
Do not emit generated code within a module

### DIFF
--- a/src/compile_fail_tests.rs
+++ b/src/compile_fail_tests.rs
@@ -254,7 +254,6 @@ mod ready_state_with_multiple_fields {
      */
 }
 
-
 mod error_state_with_multiple_fields {
     /*!
     ```compile_fail

--- a/tests/private_type_in_description.rs
+++ b/tests/private_type_in_description.rs
@@ -1,0 +1,36 @@
+//! Test that we get the expected poll results.
+
+#![allow(dead_code)]
+
+extern crate futures;
+#[macro_use]
+extern crate state_machine_future;
+
+use futures::{Poll};
+use state_machine_future::RentToOwn;
+
+struct PrivateType;
+
+// Should not get this error:
+//
+// error[E0446]: private type `PrivateType` in public interface
+//   --> tests/private_type_in_description.rs:12:10
+//    |
+// 12 | #[derive(StateMachineFuture)]
+//    |          ^^^^^^^^^^^^^^^^^^ can't leak private type
+#[derive(StateMachineFuture)]
+enum Machine {
+    #[state_machine_future(start)]
+    #[state_machine_future(transitions(Ready))]
+    Start(PrivateType),
+
+    #[state_machine_future(ready)] Ready(usize),
+
+    #[state_machine_future(error)] Error(usize),
+}
+
+impl PollMachine for Machine {
+    fn poll_start<'a>(_: &'a mut RentToOwn<'a, Start>) -> Poll<AfterStart, usize> {
+        unimplemented!()
+    }
+}


### PR DESCRIPTION
This avoids needing to figure out how to use explicit imports for non-`pub` types that don't get imported via `use super::*`.

Fixes #6