### PR TITLE
Adds support for type parameters without using PhantomData

### DIFF
--- a/derive_state_machine_future/src/ast.rs
+++ b/derive_state_machine_future/src/ast.rs
@@ -4,6 +4,8 @@ use darling;
 use phases;
 use syn;
 
+use std::collections::HashSet;
+
 /// A description of a state machine: its various states, which is the start
 /// state, ready state, and error state.
 #[derive(Debug, FromDeriveInput)]
@@ -151,6 +153,184 @@ where
             extra: (),
         };
         (state, extra)
+    }
+}
+
+pub trait CollectIdents {
+    /// Collects idents that could be a type/lifetime parameter
+    fn collect_idents(&self, idents: &mut HashSet<syn::Ident>);
+}
+
+impl CollectIdents for syn::Ty {
+    fn collect_idents(&self, idents: &mut HashSet<syn::Ident>) {
+        match *self {
+            syn::Ty::Path(ref qself, ref p) => {
+                if let &Some(ref qself) = qself {
+                    qself.ty.collect_idents(idents);
+                }
+
+                p.collect_idents(idents);
+            }
+            syn::Ty::Slice(ref ty) | syn::Ty::Paren(ref ty) => ty.collect_idents(idents),
+            syn::Ty::Ptr(ref ty) => ty.ty.collect_idents(idents),
+            syn::Ty::Rptr(ref lifetime, ref ty) => {
+                if let &Some(ref lifetime) = lifetime {
+                    idents.insert(lifetime.ident.clone());
+                }
+
+                ty.ty.collect_idents(idents)
+            }
+            syn::Ty::Tup(ref tys) => tys.iter().for_each(|v| v.collect_idents(idents)),
+            syn::Ty::BareFn(ref bfn) => bfn.collect_idents(idents),
+            syn::Ty::Array(ref ty, ref cexpr) => {
+                ty.collect_idents(idents);
+                cexpr.collect_idents(idents);
+            }
+            syn::Ty::Never
+            | syn::Ty::Mac(_)
+            | syn::Ty::TraitObject(_)
+            | syn::Ty::ImplTrait(_)
+            | syn::Ty::Infer => {}
+        }
+    }
+}
+
+impl CollectIdents for syn::ConstExpr {
+    fn collect_idents(&self, idents: &mut HashSet<syn::Ident>) {
+        match *self {
+            syn::ConstExpr::Call(ref f, ref args) => {
+                f.collect_idents(idents);
+                args.iter().for_each(|v| v.collect_idents(idents));
+            }
+            syn::ConstExpr::Binary(_, ref c0, ref c1) | syn::ConstExpr::Index(ref c0, ref c1) => {
+                c0.collect_idents(idents);
+                c1.collect_idents(idents);
+            }
+            syn::ConstExpr::Unary(_, ref c) | syn::ConstExpr::Paren(ref c) => {
+                c.collect_idents(idents)
+            }
+            syn::ConstExpr::Cast(ref c, ref ty) => {
+                ty.collect_idents(idents);
+                c.collect_idents(idents);
+            }
+            syn::ConstExpr::Path(ref p) => p.collect_idents(idents),
+            syn::ConstExpr::Lit(_) | syn::ConstExpr::Other(_) => {}
+        }
+    }
+}
+
+impl CollectIdents for syn::BareFnTy {
+    fn collect_idents(&self, idents: &mut HashSet<syn::Ident>) {
+        self.inputs.iter().for_each(|v| v.ty.collect_idents(idents));
+
+        match self.output {
+            syn::FunctionRetTy::Ty(ref ty) => ty.collect_idents(idents),
+            syn::FunctionRetTy::Default => {}
+        }
+    }
+}
+
+impl CollectIdents for syn::Path {
+    fn collect_idents(&self, idents: &mut HashSet<syn::Ident>) {
+        // If the path contains only one segment and is not a global path,
+        // it could be a generic type parameter, so we add the ident.
+        if self.segments.len() == 1 && !self.global {
+            let last = self.segments.get(0).unwrap();
+            idents.insert(last.ident.clone());
+        }
+
+        // If the path has more than one segment, it can not be a type parameter, because type
+        // parameters are absolute without any preceding segments. So, only collect
+        // the idents of the path parameters (aka type/lifetime parameters).
+        self.segments
+            .iter()
+            .for_each(|s| s.parameters.collect_idents(idents));
+    }
+}
+
+impl CollectIdents for syn::PathParameters {
+    fn collect_idents(&self, idents: &mut HashSet<syn::Ident>) {
+        match *self {
+            syn::PathParameters::AngleBracketed(ref bracket) => {
+                bracket.lifetimes.iter().for_each(|v| {
+                    idents.insert(v.ident.clone());
+                });
+                bracket.types.iter().for_each(|v| v.collect_idents(idents));
+                bracket
+                    .bindings
+                    .iter()
+                    .for_each(|v| v.ty.collect_idents(idents));
+            }
+            syn::PathParameters::Parenthesized(ref parent) => {
+                parent.inputs.iter().for_each(|v| v.collect_idents(idents));
+
+                if let Some(ref output) = parent.output {
+                    output.collect_idents(idents);
+                }
+            }
+        }
+    }
+}
+
+impl CollectIdents for syn::TyParamBound {
+    fn collect_idents(&self, idents: &mut HashSet<syn::Ident>) {
+        match *self {
+            syn::TyParamBound::Trait(ref poly, _) => {
+                poly.bound_lifetimes.iter().for_each(|l| {
+                    l.collect_idents(idents);
+                });
+
+                poly.trait_ref.collect_idents(idents);
+            }
+            syn::TyParamBound::Region(ref lifetime) => {
+                idents.insert(lifetime.ident.clone());
+            }
+        }
+    }
+}
+
+impl CollectIdents for syn::TyParam {
+    fn collect_idents(&self, idents: &mut HashSet<syn::Ident>) {
+        if let Some(ref default) = self.default {
+            default.collect_idents(idents);
+        }
+
+        self.bounds.iter().for_each(|b| b.collect_idents(idents));
+        idents.insert(self.ident.clone());
+    }
+}
+
+impl CollectIdents for syn::LifetimeDef {
+    fn collect_idents(&self, idents: &mut HashSet<syn::Ident>) {
+        self.bounds.iter().for_each(|b| {
+            idents.insert(b.ident.clone());
+        });
+        idents.insert(self.lifetime.ident.clone());
+    }
+}
+
+impl CollectIdents for syn::WherePredicate {
+    fn collect_idents(&self, idents: &mut HashSet<syn::Ident>) {
+        match *self {
+            syn::WherePredicate::BoundPredicate(ref bound) => {
+                bound.bounds.iter().for_each(|b| b.collect_idents(idents));
+                bound
+                    .bound_lifetimes
+                    .iter()
+                    .for_each(|l| l.collect_idents(idents));
+                bound.bounded_ty.collect_idents(idents);
+            }
+            syn::WherePredicate::RegionPredicate(ref region) => {
+                region.bounds.iter().for_each(|l| {
+                    idents.insert(l.ident.clone());
+                });
+                idents.insert(region.lifetime.ident.clone());
+            }
+            syn::WherePredicate::EqPredicate(ref eq) => {
+                eq.lhs_ty.collect_idents(idents);
+                eq.rhs_ty.collect_idents(idents);
+            }
+        }
     }
 }
 

--- a/derive_state_machine_future/src/lib.rs
+++ b/derive_state_machine_future/src/lib.rs
@@ -36,6 +36,8 @@ pub fn derive_state_machine_future(tokens: TokenStream) -> TokenStream {
     let machine = phases::StartReadyError::pass(machine);
     let machine = phases::ValidTransitionEdges::pass(machine);
     let machine = phases::ValidPaths::pass(machine);
+    let machine = phases::StateGenerics::pass(machine);
+    let machine = phases::AfterStateGenerics::pass(machine);
     let machine = phases::ReadyForCodegen::pass(machine);
 
     let mut tokens = quote!();

--- a/tests/cargo_readme_up_to_date.rs
+++ b/tests/cargo_readme_up_to_date.rs
@@ -12,7 +12,10 @@ fn cargo_readme_up_to_date() {
         .output()
         .expect("should run `cargo readme` OK");
 
-    assert!(output.status.success(), "Check if you have `cargo-readme` in $PATH");
+    assert!(
+        output.status.success(),
+        "Check if you have `cargo-readme` in $PATH"
+    );
     let expected = String::from_utf8_lossy(&output.stdout);
 
     let actual = {

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -11,41 +11,96 @@ use futures::{Future, Poll};
 use state_machine_future::RentToOwn;
 use std::fmt::Debug;
 use std::marker::PhantomData;
+use std::io;
+
+pub trait ComplexTrait<'a, T> {
+    fn data(&self) -> &'a T;
+}
+
+pub trait AssociatedTypesTrait {
+    type Type;
+}
+
+pub struct StartType<'a, 'c, 'd: 'a, T, C>
+where
+    T: ComplexTrait<'c, C>,
+    C: 'c,
+    'c: 'd,
+{
+    _data: T,
+    _phan: PhantomData<&'a C>,
+    _phan2: PhantomData<&'c C>,
+    _phan3: PhantomData<&'d C>,
+}
 
 #[derive(StateMachineFuture)]
-pub enum Fsm<T : 'static, E>
+pub enum Fsm<'a, 'c, 'd: 'a, T: 'static, E, C, D>
 where
-    T: Default,
+    T: ComplexTrait<'c, C>,
     E: Debug,
+    C: 'c,
+    'c: 'd,
+    D: AssociatedTypesTrait<Type=E>,
 {
     /// The start state.
     #[state_machine_future(start)]
-    #[state_machine_future(transitions(Ready, Error))]
-    Start(PhantomData<T>, PhantomData<E>),
+    #[state_machine_future(transitions(Complex, AssociatedType, Ready, Error))]
+    Start(StartType<'a, 'c, 'd, T, C>, D),
+
+    #[state_machine_future(transitions(Ready, Error))] Complex(&'a i32, &'d u32),
+
+    #[state_machine_future(transitions(Ready, Error))] AssociatedType(D),
 
     /// Some generic ready state.
     #[state_machine_future(ready)]
-    Ready((T, PhantomData<E>)),
+    Ready(i32),
 
     /// Some generic error state.
     #[state_machine_future(error)]
-    Error((E, PhantomData<T>)),
+    Error(E),
 }
 
-impl<T, E> PollFsm<T, E> for Fsm<T, E>
+impl<'a, 'c, 'd: 'a, T, E, C, D> PollFsm<'a, 'c, 'd, T, E, C, D> for Fsm<'a, 'c, 'd, T, E, C, D>
 where
-    T: Default + 'static,
+    T: ComplexTrait<'c, C> + 'static,
     E: Debug,
+    C: 'c,
+    'c: 'd,
+    D: AssociatedTypesTrait<Type=E>,
 {
-    fn poll_start<'a>(
-        _: &'a mut RentToOwn<'a, Start<T, E>>,
-    ) -> Poll<AfterStart<T, E>, (E, PhantomData<T>)> {
+    fn poll_start<'b>(
+        _: &'b mut RentToOwn<'b, Start<'a, 'c, 'd, T, E, C, D>>,
+    ) -> Poll<AfterStart<'a, 'd, E, D>, E> {
+        unimplemented!()
+    }
+
+    fn poll_complex<'b>(_: &'b mut RentToOwn<'b, Complex<'a, 'd>>) -> Poll<AfterComplex<E>, E> {
+        unimplemented!()
+    }
+
+    fn poll_associated_type<'b>(_: &'b mut RentToOwn<'b, AssociatedType<E, D>>) -> Poll<AfterAssociatedType<E>, E> {
         unimplemented!()
     }
 }
 
+impl<'a> ComplexTrait<'a, i32> for i32 {
+    fn data(&self) -> &'a i32 {
+        unimplemented!()
+    }
+}
+
+impl AssociatedTypesTrait for String {
+    type Type = io::Error;
+}
+
 #[test]
 fn check_generic_start() {
-    let _: Box<Future<Item = (usize, _), Error = (bool, _)>> =
-        Box::new(Fsm::start(PhantomData, PhantomData));
+    let test = String::from("test");
+
+    let _: Box<Future<Item = i32, Error = io::Error>> = Box::new(Fsm::start(StartType {
+        _data: 0,
+        _phan: Default::default(),
+        _phan2: Default::default(),
+        _phan3: Default::default(),
+    }, test));
 }

--- a/tests/private_type_in_description.rs
+++ b/tests/private_type_in_description.rs
@@ -4,7 +4,7 @@ extern crate futures;
 #[macro_use]
 extern crate state_machine_future;
 
-use futures::{Poll};
+use futures::Poll;
 use state_machine_future::RentToOwn;
 
 struct PrivateType;


### PR DESCRIPTION
The type parameters are filtered per state. This prevents the usage of
PhantomData in states that do not require certain type parameters.

Should fix: https://github.com/fitzgen/state_machine_future/issues/2