### PR TITLE
Add `Context` functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,84 @@ impl PollMyStateMachine for MyStateMachine {
 }
 ```
 
+### Context
+
+The state machine also allows to pass in a context that is available in every `poll_*` method
+without having to explicitly include it in every one.
+
+The context can be specified through the `context` argument of the `state_machine_future` attribute.
+This will add parameters to the `start` method as well as to each `poll_*` method of the trait.
+
+```rust
+#[macro_use]
+extern crate state_machine_future;
+extern crate futures;
+
+use futures::*;
+use state_machine_future::*;
+
+struct MyContext {
+
+}
+
+struct MyItem {
+
+}
+
+enum MyError {
+
+}
+
+#[derive(StateMachineFuture)]
+#[state_machine_future(context = "MyContext")]
+enum MyStateMachine {
+    #[state_machine_future(start, transitions(Intermediate))]
+    Start,
+
+    #[state_machine_future(transitions(Start, Ready))]
+    Intermediate { x: usize, y: usize },
+
+    #[state_machine_future(ready)]
+    Ready(MyItem),
+
+    #[state_machine_future(error)]
+    Error(MyError),
+}
+
+impl PollMyStateMachine for MyStateMachine {
+    fn poll_start<'s, 'c>(
+        start: &'s mut RentToOwn<'s, Start>,
+        context: &'c mut RentToOwn<'c, MyContext>
+    ) -> Poll<AfterStart, MyError> {
+
+        // The `context` instance passed into `start` is available here.
+        // It is a mutable reference, so are free to modify it.
+
+        unimplemented!()
+    }
+
+    fn poll_intermediate<'s, 'c>(
+        intermediate: &'s mut RentToOwn<'s, Intermediate>,
+        context: &'c mut RentToOwn<'c, MyContext>
+    ) -> Poll<AfterIntermediate, MyError> {
+
+        // The `context` is available here as well.
+        // It is the same instance. This means if `poll_start` modified it, those
+        // changes will be visible to this method as well.
+
+        unimplemented!()
+    }
+}
+
+fn main() {
+    let _ = MyStateMachine::start(MyContext { });
+}
+```
+
+Same as for the state argument, the context can be taken through the `RentToOwn` type!
+However, be aware that once you take the context, the state machine will **always** return
+`Async::NotReady` **without** invoking the `poll_` methods anymore.
+
 That's it!
 
 ### Example

--- a/derive_state_machine_future/src/ast.rs
+++ b/derive_state_machine_future/src/ast.rs
@@ -23,6 +23,16 @@ pub struct StateMachine<P: phases::Phase> {
     /// Extra per-phase data.
     #[darling(default)]
     pub extra: P::StateMachineExtra,
+
+    #[darling(default)]
+    pub context: Option<Context>
+}
+
+#[derive(Default, Debug, FromMeta)]
+#[darling(default)]
+pub struct Context {
+    #[darling(rename = "type")]
+    _type: String
 }
 
 /// In individual state in a state machine.
@@ -90,6 +100,7 @@ where
             attrs: self.attrs,
             derive: self.derive,
             extra: (),
+            context: self.context,
         };
         (machine, extra, states)
     }
@@ -118,6 +129,7 @@ impl StateMachine<phases::NoPhase> {
             attrs: self.attrs,
             derive: self.derive,
             extra,
+            context: self.context,
         }
     }
 }

--- a/derive_state_machine_future/src/ast.rs
+++ b/derive_state_machine_future/src/ast.rs
@@ -25,14 +25,7 @@ pub struct StateMachine<P: phases::Phase> {
     pub extra: P::StateMachineExtra,
 
     #[darling(default)]
-    pub context: Option<Context>
-}
-
-#[derive(Default, Debug, FromMeta)]
-#[darling(default)]
-pub struct Context {
-    #[darling(rename = "type")]
-    _type: String
+    pub context: Option<syn::Ident>,
 }
 
 /// In individual state in a state machine.

--- a/derive_state_machine_future/src/codegen.rs
+++ b/derive_state_machine_future/src/codegen.rs
@@ -217,7 +217,7 @@ impl ToTokens for StateMachine<phases::ReadyForCodegen> {
         };
 
         let context_start_arg = match self.context {
-            Some(ref ident) => quote!{
+            Some(_) => quote!{
                 , context
             },
             None => quote!{},
@@ -403,7 +403,7 @@ impl State<phases::ReadyForCodegen> {
         });
 
         let poll_method_call = match context {
-            Some(ident) => quote! {
+            Some(_) => quote! {
                 |state| {
                     <#description_ident #ty_generics as #poll_trait #ty_generics>::#poll_method(state, &mut self.1)
                 }

--- a/derive_state_machine_future/src/codegen.rs
+++ b/derive_state_machine_future/src/codegen.rs
@@ -134,7 +134,7 @@ impl ToTokens for StateMachine<phases::ReadyForCodegen> {
         let poll_trait_methods: Vec<_> = states
             .iter()
             .filter(|s| !s.ready && !s.error)
-            .map(|state| state.poll_trait_method(self.context.as_ref()))
+            .map(|state| state.poll_trait_method(&ty_generics, self.context.as_ref()))
             .collect();
 
         let start_doc = doc_string(format!(
@@ -204,14 +204,14 @@ impl ToTokens for StateMachine<phases::ReadyForCodegen> {
 
         let context_ident = match self.context {
             Some(ref ident) => quote!{
-                , #ident
+                , #ident #ty_generics
             },
             None => quote!{},
         };
 
         let context_start_arg_decl = match self.context {
             Some(ref ident) => quote!{
-                , context: #ident
+                , context: #ident #ty_generics
             },
             None => quote!{},
         };
@@ -453,7 +453,7 @@ impl State<phases::ReadyForCodegen> {
         ))
     }
 
-    fn poll_trait_method(&self, context: Option<&syn::Ident>) -> proc_macro2::TokenStream {
+    fn poll_trait_method(&self, sm_ty_generics: &syn::TypeGenerics, context: Option<&syn::Ident>) -> proc_macro2::TokenStream {
         assert!(!self.ready && !self.error);
 
         let poll_method = &self.extra.poll_method;
@@ -468,7 +468,7 @@ impl State<phases::ReadyForCodegen> {
 
         let context_param = match context {
             Some(ident) => quote! {
-                , context: &'s mut #ident
+                , context: &'s mut #ident #sm_ty_generics
             },
             None => quote!{},
         };

--- a/derive_state_machine_future/src/codegen.rs
+++ b/derive_state_machine_future/src/codegen.rs
@@ -246,7 +246,6 @@ impl ToTokens for StateMachine<phases::ReadyForCodegen> {
             }
 
             #( #state_machine_attrs )*
-            #derive
             #[must_use = "futures do nothing unless polled"]
             #vis struct #state_machine_ident #impl_generics #where_clause {
                 current_state: Option<#states_enum #ty_generics>

--- a/derive_state_machine_future/src/codegen.rs
+++ b/derive_state_machine_future/src/codegen.rs
@@ -202,6 +202,8 @@ impl ToTokens for StateMachine<phases::ReadyForCodegen> {
             })
             .collect();
 
+        let has_no_start_parameters = start_params.len() == 0;
+
         let context_field = match self.context {
             Some(ref ident) => quote!{
                 , context: Option<#ident #ty_generics>
@@ -210,6 +212,16 @@ impl ToTokens for StateMachine<phases::ReadyForCodegen> {
         };
 
         let context_start_arg_decl = match self.context {
+            Some(ref ident) if has_no_start_parameters => quote!{
+                context: #ident #ty_generics
+            },
+            Some(ref ident) => quote!{
+                , context: #ident #ty_generics
+            },
+            None => quote!{},
+        };
+
+        let context_start_in_arg_decl = match self.context {
             Some(ref ident) => quote!{
                 , context: #ident #ty_generics
             },
@@ -299,7 +311,7 @@ impl ToTokens for StateMachine<phases::ReadyForCodegen> {
                     }
                 }
 
-                #vis fn start_in<STATE: Into<#states_enum #ty_generics>>( state: STATE #context_start_arg_decl ) -> #state_machine_ident #ty_generics {
+                #vis fn start_in<STATE: Into<#states_enum #ty_generics>>( state: STATE #context_start_in_arg_decl ) -> #state_machine_ident #ty_generics {
                     #state_machine_ident {
                         current_state: Some(state.into())
                         #context_start_arg

--- a/src/compile_fail_tests.rs
+++ b/src/compile_fail_tests.rs
@@ -513,6 +513,34 @@ mod transition_to_unknown_state {
      */
 }
 
+mod derives_not_added_to_future {
+    /*!
+    ```compile_fail
+    #[macro_use]
+    extern crate state_machine_future;
+    extern crate futures;
+    use futures::*;
+    use std::fmt::Debug;
+
+    #[derive(StateMachineFuture)]
+    #[state_machine_future(derive(Debug))]
+    pub enum Debuggable {
+        #[state_machine_future(start)]
+        #[state_machine_future(ready)]
+        #[state_machine_future(error)]
+        OnlyState(()),
+    }
+
+    fn check_debug<D: Debug>(_: D) {}
+
+    fn main() {
+        check_debug(Debuggable::start(()));
+    }
+
+    ```
+     */
+}
+
 mod unreachable_intermediate_state {
     /*!
     ```compile_fail

--- a/tests/context.rs
+++ b/tests/context.rs
@@ -9,6 +9,7 @@ use futures::Async;
 use futures::Future;
 use futures::Poll;
 use state_machine_future::RentToOwn;
+use std::fmt::Debug;
 
 pub struct ExternalSource<T> {
     pub value: T,
@@ -29,7 +30,7 @@ impl<T: Clone + 'static> Context<T> {
 }
 
 #[derive(StateMachineFuture)]
-#[state_machine_future(context = "Context")]
+#[state_machine_future(context = "Context", derive(Debug))]
 pub enum WithContext<T: Clone + 'static> {
     #[state_machine_future(start, transitions(Ready))]
     Start(()),
@@ -66,3 +67,13 @@ fn can_call_to_context() {
 
     assert_eq!(machine.poll(), Ok(Async::Ready(String::from("foo"))));
 }
+
+fn check_debug<D: Debug>(_: D) {}
+
+#[test]
+fn given_sm_with_context_should_add_derives_to_states() {
+    check_debug(Start(()));
+    check_debug(Ready(10));
+    check_debug(Error(()));
+}
+

--- a/tests/context.rs
+++ b/tests/context.rs
@@ -1,0 +1,68 @@
+//! Test that we can access context type.
+
+#[macro_use]
+extern crate futures;
+#[macro_use]
+extern crate state_machine_future;
+
+use futures::Async;
+use futures::Future;
+use futures::Poll;
+use state_machine_future::RentToOwn;
+
+pub struct ExternalSource {
+    pub value: String,
+}
+
+pub struct Context {
+    pub external_source: ExternalSource,
+    pub lazy_future: Option<Box<Future<Item = String, Error = ()>>>,
+}
+
+impl Context {
+    fn load_from_external_source(&mut self) -> &mut Box<Future<Item = String, Error = ()>> {
+        let value = &self.external_source.value;
+
+        self.lazy_future
+            .get_or_insert_with(|| Box::new(futures::future::ok(value.clone())))
+    }
+}
+
+#[derive(StateMachineFuture)]
+#[state_machine_future(context = "Context")]
+pub enum WithContext {
+    #[state_machine_future(start, transitions(Ready))]
+    Start(()),
+
+    #[state_machine_future(ready)]
+    Ready(String),
+
+    #[state_machine_future(error)]
+    Error(()),
+}
+
+impl PollWithContext for WithContext {
+    fn poll_start<'a, 's>(
+        _: &'a mut RentToOwn<'a, Start>,
+        context: &'s mut Context,
+    ) -> Poll<AfterStart, ()> {
+
+        let value = try_ready!(context.load_from_external_source().poll());
+
+        transition!(Ready(value))
+    }
+}
+
+#[test]
+fn can_call_to_context() {
+
+    let source = ExternalSource {
+        value: String::from("foo"),
+    };
+
+    let context = Context { external_source: source, lazy_future: None };
+
+    let mut machine = WithContext::start((), context);
+
+    assert_eq!(machine.poll(), Ok(Async::Ready(String::from("foo"))));
+}

--- a/tests/context.rs
+++ b/tests/context.rs
@@ -42,9 +42,9 @@ pub enum WithContext<T: Clone + 'static> {
 }
 
 impl<T: Clone + 'static> PollWithContext<T> for WithContext<T> {
-    fn poll_start<'a, 's>(
-        _: &'a mut RentToOwn<'a, Start>,
-        context: &'s mut Context<T>,
+    fn poll_start<'state, 'context>(
+        _: &'state mut RentToOwn<'state, Start>,
+        context: &'context mut RentToOwn<'context, Context<T>>,
     ) -> Poll<AfterStart<T>, ()> {
 
         let value = try_ready!(context.load_from_external_source().poll());

--- a/tests/context_and_derives.rs
+++ b/tests/context_and_derives.rs
@@ -1,0 +1,27 @@
+//! Test that we can access context type.
+
+#[macro_use]
+extern crate state_machine_future;
+
+use std::fmt::Debug;
+
+pub struct Context {
+
+}
+
+#[derive(StateMachineFuture)]
+#[state_machine_future(context = "Context", derive(Debug))]
+pub enum WithContext {
+    #[state_machine_future(start)]
+    #[state_machine_future(ready)]
+    #[state_machine_future(error)]
+    OnlyState(()),
+}
+
+fn check_debug<D: Debug>(_: D) {}
+
+#[test]
+fn given_sm_with_context_should_add_derives_to_states() {
+    check_debug(OnlyState(()));
+}
+

--- a/tests/context_start_in_method.rs
+++ b/tests/context_start_in_method.rs
@@ -1,0 +1,41 @@
+//! Test that we can access context type.
+
+extern crate futures;
+#[macro_use]
+extern crate state_machine_future;
+
+use futures::Poll;
+use state_machine_future::RentToOwn;
+
+pub struct Context {
+}
+
+#[derive(StateMachineFuture)]
+#[state_machine_future(context = "Context")]
+pub enum WithContext {
+    #[state_machine_future(start, transitions(Ready))]
+    Start,
+
+    #[state_machine_future(ready)]
+    Ready(()),
+
+    #[state_machine_future(error)]
+    Error(()),
+}
+
+impl PollWithContext for WithContext {
+    fn poll_start<'s, 'c>(
+        _: &'s mut RentToOwn<'s, Start>,
+        _: &'c mut RentToOwn<'c, Context>,
+    ) -> Poll<AfterStart, ()> {
+        unimplemented!()
+    }
+}
+
+#[test]
+fn given_sm_with_no_start_args_only_takes_context() {
+
+    let context = Context {};
+
+    let _ = WithContext::start_in(Ready(()), context);
+}

--- a/tests/context_start_method.rs
+++ b/tests/context_start_method.rs
@@ -1,0 +1,41 @@
+//! Test that we can access context type.
+
+extern crate futures;
+#[macro_use]
+extern crate state_machine_future;
+
+use futures::Poll;
+use state_machine_future::RentToOwn;
+
+pub struct Context {
+}
+
+#[derive(StateMachineFuture)]
+#[state_machine_future(context = "Context")]
+pub enum WithContext {
+    #[state_machine_future(start, transitions(Ready))]
+    Start,
+
+    #[state_machine_future(ready)]
+    Ready(()),
+
+    #[state_machine_future(error)]
+    Error(()),
+}
+
+impl PollWithContext for WithContext {
+    fn poll_start<'s, 'c>(
+        _: &'s mut RentToOwn<'s, Start>,
+        _: &'c mut RentToOwn<'c, Context>,
+    ) -> Poll<AfterStart, ()> {
+        unimplemented!()
+    }
+}
+
+#[test]
+fn given_sm_with_no_start_args_only_takes_context() {
+
+    let context = Context {};
+
+    let _ = WithContext::start(context);
+}

--- a/tests/derives.rs
+++ b/tests/derives.rs
@@ -22,7 +22,3 @@ fn state_derived_debug() {
     check_debug(OnlyState(()));
 }
 
-#[test]
-fn state_machine_derived_debug() {
-    check_debug(Debuggable::start(()));
-}


### PR DESCRIPTION
Hi,

first of, thank you very much for this great library! It almost exactly fits our needs! I haven't done anything with custom derives before. so feedback to my changes is very much appreciated. I'll shortly explain what I am trying to achieve:

We want to be able to persist the states used by the state machine. To make this easier, we figured it would be great if the individual states would only store data, e.g. easily persistable structs. But this excludes storing the futures in there that actually drive the state machine.

The idea is to introduce a `Context` that you pass in as the state machine is started. Later on, you can be access the context in each poll method. I tried to outline the usage in the test I added.

So far it is working!

However, given I have never worked with custom derives before, I don't know about potential pitfalls when generating code. I am also very unsure if my changes are idiomatic or whether the needed functionality could be achieved in a simpler manner.