### PR TITLE
Install cargo-readme with stable toolchain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: rust
 cache: cargo
 
 before_script:
-  - cargo install -f cargo-readme
+  - which cargo-readme || (rustup install stable && cargo +stable install cargo-readme)
 
 rust:
   - 1.21.0


### PR DESCRIPTION
Instead of installing cargo-readme everytime, we check if it is available and install it via the stable toolchain if it is not yet there. This is needed because we test against rust version 1.21 which is not capable of compiling the dependency tree of cargo-readme.

As a nice side effect, the build should be slightly faster because `cargo-readme` is not installed every time :)

Resolves #35.