### PR TITLE
Allow context to be taken when ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,9 @@ fn main() {
 
 Same as for the state argument, the context can be taken through the `RentToOwn` type!
 However, be aware that once you take the context, the state machine will **always** return
-`Async::NotReady` **without** invoking the `poll_` methods anymore.
+`Async::NotReady` **without** invoking the `poll_` methods anymore. The one exception to
+this is when the state machine is in a ready or error state, where it will resolve normally
+when polled if the context has been taken.
 
 That's it!
 

--- a/derive_state_machine_future/src/codegen.rs
+++ b/derive_state_machine_future/src/codegen.rs
@@ -48,6 +48,7 @@ impl ToTokens for StateMachine<phases::ReadyForCodegen> {
         let vis = &self.vis;
         let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
         let states = self.states();
+        let total_states = states.len();
 
         let derive = if self.derive.is_empty() {
             quote!{}
@@ -74,6 +75,8 @@ impl ToTokens for StateMachine<phases::ReadyForCodegen> {
         let start_state_ident = &start.ident;
 
         let ready = &states[self.extra.ready];
+        let ready_state_ident = &ready.ident;
+        let ready_var = to_var(&ready_state_ident.to_string());
         let future_item = &ready.fields.fields[0];
 
         let error = &states[self.extra.error];
@@ -235,11 +238,29 @@ impl ToTokens for StateMachine<phases::ReadyForCodegen> {
         };
 
         let extract_context = match self.context {
-            Some(_) => quote!{
-                let context = match self.context.take() {
-                    Some(context) => context,
-                    None => return Ok(#smf_crate::export::Async::NotReady),
-                };
+            Some(_) => match total_states {
+                // If there is only 1 state it is irrefutable that we are
+                // in the ready state.
+                1 => quote!{
+                    let context = match self.context.take() {
+                        Some(context) => context,
+                        None => {
+                            let #states_enum::#ready_state_ident(#ready_state_ident(#ready_var)) = state;
+                            return Ok(#smf_crate::export::Async::Ready(#ready_var))
+                        }
+                    };
+                },
+                _ => quote!{
+                    let context = match self.context.take() {
+                        Some(context) => context,
+                        None => {
+                            if let #states_enum::#ready_state_ident(#ready_state_ident(#ready_var)) = state {
+                                return Ok(#smf_crate::export::Async::Ready(#ready_var))
+                            };
+                            return Ok(#smf_crate::export::Async::NotReady)
+                        }
+                    };
+                },
             },
             None => quote!{},
         };

--- a/derive_state_machine_future/src/codegen.rs
+++ b/derive_state_machine_future/src/codegen.rs
@@ -241,8 +241,7 @@ impl ToTokens for StateMachine<phases::ReadyForCodegen> {
 
         let extract_context = match self.context {
             Some(_) => match total_states {
-                // If there is only 1 state it is irrefutable that we are
-                // in the ready state.
+                // If there is only 1 state it is irrefutable that we are in the ready state.
                 1 => quote!{
                     let context = match self.context.take() {
                         Some(context) => context,

--- a/derive_state_machine_future/src/codegen.rs
+++ b/derive_state_machine_future/src/codegen.rs
@@ -256,13 +256,11 @@ impl ToTokens for StateMachine<phases::ReadyForCodegen> {
                     let context = match self.context.take() {
                         Some(context) => context,
                         None => {
-                            if let #states_enum::#ready_ident(#ready_ident(#ready_var)) = state {
-                                return Ok(#smf_crate::export::Async::Ready(#ready_var))
-                            };
-                            if let #states_enum::#error_ident(#error_ident(#error_var)) = state {
-                                return Err(#error_var);
-                            };
-                            return Ok(#smf_crate::export::Async::NotReady)
+                            return match state {
+                                #states_enum::#ready_ident(#ready_ident(#ready_var)) => Ok(#smf_crate::export::Async::Ready(#ready_var)),
+                                #states_enum::#error_ident(#error_ident(#error_var)) => Err(#error_var),
+                                _ => Ok(#smf_crate::export::Async::NotReady)
+                            }
                         }
                     };
                 },

--- a/derive_state_machine_future/src/codegen.rs
+++ b/derive_state_machine_future/src/codegen.rs
@@ -75,11 +75,13 @@ impl ToTokens for StateMachine<phases::ReadyForCodegen> {
         let start_state_ident = &start.ident;
 
         let ready = &states[self.extra.ready];
-        let ready_state_ident = &ready.ident;
-        let ready_var = to_var(&ready_state_ident.to_string());
+        let ready_ident = &ready.ident;
+        let ready_var = to_var(&ready_ident.to_string());
         let future_item = &ready.fields.fields[0];
 
         let error = &states[self.extra.error];
+        let error_ident = &error.ident;
+        let error_var = to_var(&error_ident.to_string());
         let future_error = &error.fields.fields[0];
 
         let state_machine_attrs = &self.attrs;
@@ -245,7 +247,7 @@ impl ToTokens for StateMachine<phases::ReadyForCodegen> {
                     let context = match self.context.take() {
                         Some(context) => context,
                         None => {
-                            let #states_enum::#ready_state_ident(#ready_state_ident(#ready_var)) = state;
+                            let #states_enum::#ready_ident(#ready_ident(#ready_var)) = state;
                             return Ok(#smf_crate::export::Async::Ready(#ready_var))
                         }
                     };
@@ -254,8 +256,11 @@ impl ToTokens for StateMachine<phases::ReadyForCodegen> {
                     let context = match self.context.take() {
                         Some(context) => context,
                         None => {
-                            if let #states_enum::#ready_state_ident(#ready_state_ident(#ready_var)) = state {
+                            if let #states_enum::#ready_ident(#ready_ident(#ready_var)) = state {
                                 return Ok(#smf_crate::export::Async::Ready(#ready_var))
+                            };
+                            if let #states_enum::#error_ident(#error_ident(#error_var)) = state {
+                                return Err(#error_var);
                             };
                             return Ok(#smf_crate::export::Async::NotReady)
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,7 +310,9 @@ fn main() {
 
 Same as for the state argument, the context can be taken through the `RentToOwn` type!
 However, be aware that once you take the context, the state machine will **always** return
-`Async::NotReady` **without** invoking the `poll_` methods anymore.
+`Async::NotReady` **without** invoking the `poll_` methods anymore. The one exception to
+this is when the state machine is in a ready or error state, where it will resolve normally
+when polled if the context has been taken.
 
 That's it!
 

--- a/tests/take_context_on_error.rs
+++ b/tests/take_context_on_error.rs
@@ -1,0 +1,46 @@
+//! Test that we can take context when transitioning to error.
+
+extern crate futures;
+#[macro_use]
+extern crate state_machine_future;
+
+use futures::Future;
+use futures::Poll;
+use state_machine_future::RentToOwn;
+
+pub struct Context {
+}
+
+#[derive(StateMachineFuture)]
+#[state_machine_future(context = "Context")]
+pub enum WithContext {
+    #[state_machine_future(start, transitions(Ready))]
+    Start,
+
+    #[state_machine_future(ready)]
+    Ready(()),
+
+    #[state_machine_future(error)]
+    Error(()),
+}
+
+impl PollWithContext for WithContext {
+    fn poll_start<'s, 'c>(
+        _: &'s mut RentToOwn<'s, Start>,
+        context: &'c mut RentToOwn<'c, Context>,
+    ) -> Poll<AfterStart, ()> {
+        context.take();
+
+        Err(())
+    }
+}
+
+#[test]
+fn given_sm_with_context_can_take_context_on_error() {
+
+    let context = Context {};
+
+    let mut machine = WithContext::start(context);
+
+    assert_eq!(machine.poll(), Err(()));
+}

--- a/tests/take_context_on_ready.rs
+++ b/tests/take_context_on_ready.rs
@@ -1,0 +1,47 @@
+//! Test that we can take context when transitioning to ready.
+
+extern crate futures;
+#[macro_use]
+extern crate state_machine_future;
+
+use futures::Async;
+use futures::Future;
+use futures::Poll;
+use state_machine_future::RentToOwn;
+
+pub struct Context {
+}
+
+#[derive(StateMachineFuture)]
+#[state_machine_future(context = "Context")]
+pub enum WithContext {
+    #[state_machine_future(start, transitions(Ready))]
+    Start,
+
+    #[state_machine_future(ready)]
+    Ready(()),
+
+    #[state_machine_future(error)]
+    Error(()),
+}
+
+impl PollWithContext for WithContext {
+    fn poll_start<'s, 'c>(
+        _: &'s mut RentToOwn<'s, Start>,
+        context: &'c mut RentToOwn<'c, Context>,
+    ) -> Poll<AfterStart, ()> {
+        context.take();
+
+        transition!(Ready(()))
+    }
+}
+
+#[test]
+fn given_sm_with_context_can_take_context_on_ready() {
+
+    let context = Context {};
+
+    let mut machine = WithContext::start(context);
+
+    assert_eq!(machine.poll(), Ok(Async::Ready(())));
+}

--- a/tests/take_context_value_on_ready.rs
+++ b/tests/take_context_value_on_ready.rs
@@ -1,0 +1,52 @@
+//! Test that we can take a value from context when transitioning to ready.
+
+extern crate futures;
+#[macro_use]
+extern crate state_machine_future;
+
+use futures::Async;
+use futures::Future;
+use futures::Poll;
+use state_machine_future::RentToOwn;
+
+pub struct Context {
+    value: String,
+}
+
+#[derive(StateMachineFuture)]
+#[state_machine_future(context = "Context")]
+pub enum WithContext {
+    #[state_machine_future(start, transitions(Ready))]
+    Start,
+
+    #[state_machine_future(ready)]
+    Ready(String),
+
+    #[state_machine_future(error)]
+    Error(()),
+}
+
+impl PollWithContext for WithContext {
+    fn poll_start<'s, 'c>(
+        _: &'s mut RentToOwn<'s, Start>,
+        context: &'c mut RentToOwn<'c, Context>,
+    ) -> Poll<AfterStart, ()> {
+        let context = context.take();
+
+        let value = context.value;
+
+        transition!(Ready(value))
+    }
+}
+
+#[test]
+fn given_sm_with_context_can_take_context_value_on_ready() {
+
+    let context = Context {
+        value: String::from("foo"),
+    };
+
+    let mut machine = WithContext::start(context);
+
+    assert_eq!(machine.poll(), Ok(Async::Ready(String::from("foo"))));
+}


### PR DESCRIPTION
This commit adds code generation that allows a context to be taken in a
state before the machine transitions into the ready state. This is
necessary if the user wishes to move a value out of the context into
their ready value.

I described the reasons behind doing so here: https://github.com/fitzgen/state_machine_future/issues/41 but I am unsure if this is the best way to implement this functionality or if it is wanted. Pointers greatly appreciated!