### PR TITLE
Nightly rustfmt on all files

### DIFF
--- a/derive_state_machine_future/src/ast.rs
+++ b/derive_state_machine_future/src/ast.rs
@@ -7,7 +7,11 @@ use syn;
 /// A description of a state machine: its various states, which is the start
 /// state, ready state, and error state.
 #[derive(Debug, FromDeriveInput)]
-#[darling(attributes(state_machine_future), supports(enum_any), forward_attrs(allow, cfg))]
+#[darling(
+    attributes(state_machine_future),
+    supports(enum_any),
+    forward_attrs(allow, cfg)
+)]
 pub struct StateMachine<P: phases::Phase> {
     pub ident: syn::Ident,
     pub vis: syn::Visibility,
@@ -30,8 +34,10 @@ pub struct StateMachine<P: phases::Phase> {
 
 /// In individual state in a state machine.
 #[derive(Debug, FromVariant)]
-#[darling(attributes(state_machine_future, transitions, start, ready, error),
-          forward_attrs(allow, doc, cfg))]
+#[darling(
+    attributes(state_machine_future, transitions, start, ready, error),
+    forward_attrs(allow, doc, cfg)
+)]
 pub struct State<P: phases::Phase> {
     pub ident: syn::Ident,
     pub attrs: Vec<syn::Attribute>,
@@ -67,8 +73,11 @@ where
     pub fn and_then<F, Q>(self, mut f: F) -> StateMachine<Q>
     where
         Q: phases::Phase,
-        F: FnMut(StateMachine<phases::NoPhase>, P::StateMachineExtra, Vec<State<P>>)
-            -> StateMachine<Q>,
+        F: FnMut(
+            StateMachine<phases::NoPhase>,
+            P::StateMachineExtra,
+            Vec<State<P>>,
+        ) -> StateMachine<Q>,
     {
         let (state_machine, extra, states) = self.split();
         f(state_machine, extra, states)

--- a/derive_state_machine_future/src/codegen.rs
+++ b/derive_state_machine_future/src/codegen.rs
@@ -51,7 +51,7 @@ impl ToTokens for StateMachine<phases::ReadyForCodegen> {
         let total_states = states.len();
 
         let derive = if self.derive.is_empty() {
-            quote!{}
+            quote! {}
         } else {
             let derive = &*self.derive;
             quote! {
@@ -154,7 +154,8 @@ impl ToTokens for StateMachine<phases::ReadyForCodegen> {
         quiet += &state_machine_name.to_snake_case();
         let quiet = Ident::new(&quiet, Span::call_site());
 
-        let quiet_constructions: Vec<_> = self.states()
+        let quiet_constructions: Vec<_> = self
+            .states()
             .iter()
             .map(|s| {
                 let s_ident = &s.ident;
@@ -209,40 +210,40 @@ impl ToTokens for StateMachine<phases::ReadyForCodegen> {
         let has_no_start_parameters = start_params.len() == 0;
 
         let context_field = match self.context {
-            Some(ref ident) => quote!{
+            Some(ref ident) => quote! {
                 , context: Option<#ident #ty_generics>
             },
-            None => quote!{},
+            None => quote! {},
         };
 
         let context_start_arg_decl = match self.context {
-            Some(ref ident) if has_no_start_parameters => quote!{
+            Some(ref ident) if has_no_start_parameters => quote! {
                 context: #ident #ty_generics
             },
-            Some(ref ident) => quote!{
+            Some(ref ident) => quote! {
                 , context: #ident #ty_generics
             },
-            None => quote!{},
+            None => quote! {},
         };
 
         let context_start_in_arg_decl = match self.context {
-            Some(ref ident) => quote!{
+            Some(ref ident) => quote! {
                 , context: #ident #ty_generics
             },
-            None => quote!{},
+            None => quote! {},
         };
 
         let context_start_arg = match self.context {
-            Some(_) => quote!{
+            Some(_) => quote! {
                 , context: Some(context)
             },
-            None => quote!{},
+            None => quote! {},
         };
 
         let extract_context = match self.context {
             Some(_) => match total_states {
                 // If there is only 1 state it is irrefutable that we are in the ready state.
-                1 => quote!{
+                1 => quote! {
                     let context = match self.context.take() {
                         Some(context) => context,
                         None => {
@@ -251,7 +252,7 @@ impl ToTokens for StateMachine<phases::ReadyForCodegen> {
                         }
                     };
                 },
-                _ => quote!{
+                _ => quote! {
                     let context = match self.context.take() {
                         Some(context) => context,
                         None => {
@@ -264,7 +265,7 @@ impl ToTokens for StateMachine<phases::ReadyForCodegen> {
                     };
                 },
             },
-            None => quote!{},
+            None => quote! {},
         };
 
         tokens.append_all(quote! {
@@ -405,7 +406,11 @@ impl ToTokens for StateMachine<phases::ReadyForCodegen> {
 }
 
 impl State<phases::ReadyForCodegen> {
-    fn future_poll_match_arm(&self, ty_generics: &syn::TypeGenerics, context: Option<&syn::Ident>) -> proc_macro2::TokenStream {
+    fn future_poll_match_arm(
+        &self,
+        ty_generics: &syn::TypeGenerics,
+        context: Option<&syn::Ident>,
+    ) -> proc_macro2::TokenStream {
         let ident = &self.ident;
         let ident_string = ident.to_string();
         let var = to_var(&ident_string);
@@ -425,7 +430,7 @@ impl State<phases::ReadyForCodegen> {
         let error_var = to_var(error_ident.to_string());
 
         if self.error {
-            return quote!{
+            return quote! {
                 #states_enum::#error_ident(#error_ident(#error_var)) => {
                     return Err(#error_var);
                 }
@@ -499,14 +504,18 @@ impl State<phases::ReadyForCodegen> {
             self.ident.to_string(),
             self.extra.after,
             {
-                let mut t = quote!{};
+                let mut t = quote! {};
                 self.extra.error_type.to_tokens(&mut t);
                 t.to_string()
             },
         ))
     }
 
-    fn poll_trait_method(&self, sm_ty_generics: &syn::TypeGenerics, context: Option<&syn::Ident>) -> proc_macro2::TokenStream {
+    fn poll_trait_method(
+        &self,
+        sm_ty_generics: &syn::TypeGenerics,
+        context: Option<&syn::Ident>,
+    ) -> proc_macro2::TokenStream {
         assert!(!self.ready && !self.error);
 
         let poll_method = &self.extra.poll_method;
@@ -522,7 +531,7 @@ impl State<phases::ReadyForCodegen> {
             Some(ident) => quote! {
                 , _: &'smf_poll_context mut #smf_crate::RentToOwn<'smf_poll_context, #ident #sm_ty_generics>
             },
-            None => quote!{},
+            None => quote! {},
         };
 
         quote! {
@@ -546,7 +555,7 @@ impl ToTokens for State<phases::ReadyForCodegen> {
             self.extra.after_state_generics.split_for_impl();
 
         let derive = if self.extra.derive.is_empty() {
-            quote!{}
+            quote! {}
         } else {
             let derive = &**self.extra.derive;
             quote! {
@@ -554,12 +563,16 @@ impl ToTokens for State<phases::ReadyForCodegen> {
             }
         };
 
-        let fields: Vec<_> = self.fields
+        let fields: Vec<_> = self
+            .fields
             .fields
             .iter()
             .map(|f| {
                 let mut f = f.clone();
-                f.vis = syn::VisPublic { pub_token: <Token![pub]>::default() }.into();
+                f.vis = syn::VisPublic {
+                    pub_token: <Token![pub]>::default(),
+                }
+                .into();
                 f
             })
             .collect();
@@ -590,7 +603,8 @@ impl ToTokens for State<phases::ReadyForCodegen> {
 
         let after_ident = &self.extra.after;
 
-        let after_variants: Vec<_> = self.extra
+        let after_variants: Vec<_> = self
+            .extra
             .transition_state_generics
             .iter()
             .map(|(s, g)| {
@@ -606,7 +620,8 @@ impl ToTokens for State<phases::ReadyForCodegen> {
             })
             .collect();
 
-        let after_froms: Vec<_> = self.extra
+        let after_froms: Vec<_> = self
+            .extra
             .transition_state_generics
             .iter()
             .map(|(s, g)| {

--- a/derive_state_machine_future/src/lib.rs
+++ b/derive_state_machine_future/src/lib.rs
@@ -13,11 +13,9 @@ extern crate quote;
 #[macro_use]
 extern crate syn;
 
-
 mod ast;
 mod codegen;
 mod phases;
-
 
 use darling::FromDeriveInput;
 use proc_macro::TokenStream;

--- a/derive_state_machine_future/src/phases.rs
+++ b/derive_state_machine_future/src/phases.rs
@@ -8,8 +8,8 @@ use std::rc::Rc;
 
 use darling;
 use darling::usage::{
-    CollectLifetimes, CollectTypeParams,
-    GenericsExt, IdentRefSet, LifetimeRefSet, Purpose, UsesTypeParams,
+    CollectLifetimes, CollectTypeParams, GenericsExt, IdentRefSet, LifetimeRefSet, Purpose,
+    UsesTypeParams,
 };
 use heck::SnakeCase;
 use petgraph;
@@ -25,7 +25,7 @@ use ast::StateMachine;
 macro_rules! dummy_from_meta {
     ( $t:ty ) => {
         impl darling::FromMeta for $t {}
-    }
+    };
 }
 
 // Same as above.
@@ -36,7 +36,7 @@ macro_rules! dummy_default {
                 panic!("dummy implementation")
             }
         }
-    }
+    };
 }
 
 /// A phase represents a state in the pipeline, and the extra data we've
@@ -406,17 +406,21 @@ impl Pass for StateGenerics {
                 // E.g. for `'a: 'b + 'c` the hash map wil have:
                 // * `'a` as key;
                 // * `'a: 'b + 'c` as value.
-                let where_clause_lifetimes = mgenerics.where_clause.as_ref().map(|where_clause| {
-                    into_group_map(where_clause.predicates.iter().filter_map(|predicate| {
-                        match *predicate {
-                            syn::WherePredicate::Type(_) => None,
-                            syn::WherePredicate::Lifetime(ref lifetime_def) => {
-                                Some((&lifetime_def.lifetime, predicate))
-                            },
-                            syn::WherePredicate::Eq(_) => None,
-                        }
-                    }))
-                }).unwrap_or_else(HashMap::new);
+                let where_clause_lifetimes = mgenerics
+                    .where_clause
+                    .as_ref()
+                    .map(|where_clause| {
+                        into_group_map(where_clause.predicates.iter().filter_map(|predicate| {
+                            match *predicate {
+                                syn::WherePredicate::Type(_) => None,
+                                syn::WherePredicate::Lifetime(ref lifetime_def) => {
+                                    Some((&lifetime_def.lifetime, predicate))
+                                }
+                                syn::WherePredicate::Eq(_) => None,
+                            }
+                        }))
+                    })
+                    .unwrap_or_else(HashMap::new);
 
                 // Collect type parameter identifiers in where clauses with respective type and
                 // equality predicates.
@@ -428,24 +432,30 @@ impl Pass for StateGenerics {
                 // Or e.g. for `X = Bar` the hash map will have:
                 // * `X` as key;
                 // * `X = Bar` as value.
-                let where_clause_types = mgenerics.where_clause.as_ref().map(|where_clause| {
-                    let declared_type_params_ref = &declared_type_params;
-                    into_group_map_multikey(where_clause.predicates.iter().filter_map(|predicate| {
-                        match *predicate {
-                            syn::WherePredicate::Type(ref type_param) => {
-                                let idents = type_param.bounded_ty
-                                    .uses_type_params(&options, declared_type_params_ref);
-                                Some((idents, predicate))
+                let where_clause_types = mgenerics
+                    .where_clause
+                    .as_ref()
+                    .map(|where_clause| {
+                        let declared_type_params_ref = &declared_type_params;
+                        into_group_map_multikey(where_clause.predicates.iter().filter_map(
+                            |predicate| match *predicate {
+                                syn::WherePredicate::Type(ref type_param) => {
+                                    let idents = type_param
+                                        .bounded_ty
+                                        .uses_type_params(&options, declared_type_params_ref);
+                                    Some((idents, predicate))
+                                }
+                                syn::WherePredicate::Lifetime(_) => None,
+                                syn::WherePredicate::Eq(ref eq) => {
+                                    let idents = eq
+                                        .lhs_ty
+                                        .uses_type_params(&options, declared_type_params_ref);
+                                    Some((idents, predicate))
+                                }
                             },
-                            syn::WherePredicate::Lifetime(_) => None,
-                            syn::WherePredicate::Eq(ref eq) => {
-                                let idents = eq.lhs_ty
-                                    .uses_type_params(&options, declared_type_params_ref);
-                                Some((idents, predicate))
-                            },
-                        }
-                    }))
-                }).unwrap_or_else(HashMap::new);
+                        ))
+                    })
+                    .unwrap_or_else(HashMap::new);
 
                 states
                     .into_iter()
@@ -456,9 +466,13 @@ impl Pass for StateGenerics {
                         state.and_then(|state, ()| {
                             // Lifetimes and type parameter identifiers for processing in any
                             // current iteration.
-                            let mut current_lifetimes = state.fields.fields
+                            let mut current_lifetimes = state
+                                .fields
+                                .fields
                                 .collect_lifetimes(&options, &declared_lifetimes);
-                            let mut current_type_params = state.fields.fields
+                            let mut current_type_params = state
+                                .fields
+                                .fields
                                 .collect_type_params(&options, &declared_type_params);
 
                             // Lifetimes and type parameter identifiers we already processed.
@@ -500,31 +514,49 @@ impl Pass for StateGenerics {
                                 }
 
                                 // Collect lifetimes for the next_iteration.
-                                let new_lifetimes = current_lifetimes.iter().flat_map(|lifetime| {
-                                    new_elems_from_elem!(
-                                        lifetime, lifetime_defs, where_clause_lifetimes,
-                                        collect_lifetimes, declared_lifetimes,
-                                    )
-                                }).chain(current_type_params.iter().flat_map(|ident| {
-                                    new_elems_from_elem!(
-                                        ident, type_param_defs, where_clause_types,
-                                        collect_lifetimes, declared_lifetimes,
-                                    )
-                                })).filter(|lifetime| {
-                                    !state_lifetimes.contains(lifetime)
-                                        && !current_lifetimes.contains(lifetime)
-                                }).collect();
+                                let new_lifetimes = current_lifetimes
+                                    .iter()
+                                    .flat_map(|lifetime| {
+                                        new_elems_from_elem!(
+                                            lifetime,
+                                            lifetime_defs,
+                                            where_clause_lifetimes,
+                                            collect_lifetimes,
+                                            declared_lifetimes,
+                                        )
+                                    })
+                                    .chain(current_type_params.iter().flat_map(|ident| {
+                                        new_elems_from_elem!(
+                                            ident,
+                                            type_param_defs,
+                                            where_clause_types,
+                                            collect_lifetimes,
+                                            declared_lifetimes,
+                                        )
+                                    }))
+                                    .filter(|lifetime| {
+                                        !state_lifetimes.contains(lifetime)
+                                            && !current_lifetimes.contains(lifetime)
+                                    })
+                                    .collect();
 
                                 // Collect type parameter identifiers for the next iteration.
-                                let new_type_params = current_type_params.iter().flat_map(|ident| {
-                                    new_elems_from_elem!(
-                                        ident, type_param_defs, where_clause_types,
-                                        collect_type_params, declared_type_params,
-                                    )
-                                }).filter(|ident| {
-                                    !state_type_params.contains(ident)
-                                        && !current_type_params.contains(ident)
-                                }).collect();
+                                let new_type_params = current_type_params
+                                    .iter()
+                                    .flat_map(|ident| {
+                                        new_elems_from_elem!(
+                                            ident,
+                                            type_param_defs,
+                                            where_clause_types,
+                                            collect_type_params,
+                                            declared_type_params,
+                                        )
+                                    })
+                                    .filter(|ident| {
+                                        !state_type_params.contains(ident)
+                                            && !current_type_params.contains(ident)
+                                    })
+                                    .collect();
 
                                 // Prepare the loop state for the next iteration.
                                 state_lifetimes.extend(current_lifetimes);
@@ -566,18 +598,18 @@ impl Pass for StateGenerics {
                                 let where_preds_lifetimes = state_lifetimes
                                     .iter()
                                     .filter_map(|lifetime| {
-                                        where_clause_lifetimes.get(lifetime).map(|predicates| {
-                                            predicates.iter().map(|&p| p.clone())
-                                        })
+                                        where_clause_lifetimes
+                                            .get(lifetime)
+                                            .map(|predicates| predicates.iter().map(|&p| p.clone()))
                                     })
                                     .flat_map(|ps| ps);
 
                                 let where_preds_types = state_type_params
                                     .iter()
                                     .filter_map(|ident| {
-                                        where_clause_types.get(ident).map(|predicates| {
-                                            predicates.iter().map(|&p| p.clone())
-                                        })
+                                        where_clause_types
+                                            .get(ident)
+                                            .map(|predicates| predicates.iter().map(|&p| p.clone()))
                                     })
                                     .flat_map(|ps| ps);
 
@@ -674,7 +706,8 @@ impl Pass for AfterStateGenerics {
                                     })
                                     .cloned();
 
-                                type_params.map(syn::GenericParam::Type)
+                                type_params
+                                    .map(syn::GenericParam::Type)
                                     .chain(lifetimes.map(syn::GenericParam::Lifetime))
                                     .collect()
                             };

--- a/src/transition.rs
+++ b/src/transition.rs
@@ -1,5 +1,7 @@
 /// Auxiliary macro for `poll_state_xy` functions to transition into a new state.
 #[macro_export]
 macro_rules! transition {
-    ( $new_state:expr ) => (return Ok(::futures::Async::Ready($new_state.into())));
+    ( $new_state:expr ) => {
+        return Ok(::futures::Async::Ready($new_state.into()));
+    };
 }

--- a/tests/call_to_context.rs
+++ b/tests/call_to_context.rs
@@ -46,7 +46,6 @@ impl<T: Clone + 'static> PollWithContext<T> for WithContext<T> {
         _: &'s mut RentToOwn<'s, Start>,
         context: &'c mut RentToOwn<'c, Context<T>>,
     ) -> Poll<AfterStart<T>, ()> {
-
         let value = try_ready!(context.load_from_external_source().poll());
 
         transition!(Ready(value))
@@ -55,12 +54,14 @@ impl<T: Clone + 'static> PollWithContext<T> for WithContext<T> {
 
 #[test]
 fn can_call_to_context() {
-
     let source = ExternalSource {
         value: String::from("foo"),
     };
 
-    let context = Context { external_source: source, lazy_future: None };
+    let context = Context {
+        external_source: source,
+        lazy_future: None,
+    };
 
     let mut machine = WithContext::start((), context);
 

--- a/tests/context_and_derives.rs
+++ b/tests/context_and_derives.rs
@@ -5,9 +5,7 @@ extern crate state_machine_future;
 
 use std::fmt::Debug;
 
-pub struct Context {
-
-}
+pub struct Context {}
 
 #[derive(StateMachineFuture)]
 #[state_machine_future(context = "Context", derive(Debug))]
@@ -24,4 +22,3 @@ fn check_debug<D: Debug>(_: D) {}
 fn given_sm_with_context_should_add_derives_to_states() {
     check_debug(OnlyState(()));
 }
-

--- a/tests/context_start_in_method.rs
+++ b/tests/context_start_in_method.rs
@@ -7,8 +7,7 @@ extern crate state_machine_future;
 use futures::Poll;
 use state_machine_future::RentToOwn;
 
-pub struct Context {
-}
+pub struct Context {}
 
 #[derive(StateMachineFuture)]
 #[state_machine_future(context = "Context")]
@@ -34,7 +33,6 @@ impl PollWithContext for WithContext {
 
 #[test]
 fn given_sm_with_no_start_args_only_takes_context() {
-
     let context = Context {};
 
     let _ = WithContext::start_in(Ready(()), context);

--- a/tests/context_start_method.rs
+++ b/tests/context_start_method.rs
@@ -7,8 +7,7 @@ extern crate state_machine_future;
 use futures::Poll;
 use state_machine_future::RentToOwn;
 
-pub struct Context {
-}
+pub struct Context {}
 
 #[derive(StateMachineFuture)]
 #[state_machine_future(context = "Context")]
@@ -34,7 +33,6 @@ impl PollWithContext for WithContext {
 
 #[test]
 fn given_sm_with_no_start_args_only_takes_context() {
-
     let context = Context {};
 
     let _ = WithContext::start(context);

--- a/tests/derives.rs
+++ b/tests/derives.rs
@@ -21,4 +21,3 @@ fn check_debug<D: Debug>(_: D) {}
 fn state_derived_debug() {
     check_debug(OnlyState(()));
 }
-

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -10,8 +10,8 @@ extern crate state_machine_future;
 use futures::{Future, Poll};
 use state_machine_future::RentToOwn;
 use std::fmt::Debug;
-use std::marker::PhantomData;
 use std::io;
+use std::marker::PhantomData;
 
 pub trait ComplexTrait<'a, T> {
     fn data(&self) -> &'a T;

--- a/tests/name_collisions.rs
+++ b/tests/name_collisions.rs
@@ -11,9 +11,13 @@ fn futures() {}
 fn state_machine_future() {}
 
 #[allow(unused_macros)]
-macro_rules! futures { () => {} }
+macro_rules! futures {
+    () => {};
+}
 #[allow(unused_macros)]
-macro_rules! state_machine_future { () => {} }
+macro_rules! state_machine_future {
+    () => {};
+}
 
 #[derive(StateMachineFuture)]
 pub enum Fsm {

--- a/tests/start_in.rs
+++ b/tests/start_in.rs
@@ -5,7 +5,7 @@ extern crate futures;
 extern crate state_machine_future;
 
 use futures::Poll;
-use state_machine_future::{RentToOwn};
+use state_machine_future::RentToOwn;
 
 #[derive(StateMachineFuture)]
 pub enum Fsm {
@@ -29,7 +29,9 @@ pub enum Fsm {
 fn can_start_in_all_states() {
     Fsm::start_in(Begin);
     Fsm::start_in(Middle1 { number: 10 });
-    Fsm::start_in(Middle2 { string: String::from("Hello!") });
+    Fsm::start_in(Middle2 {
+        string: String::from("Hello!"),
+    });
     Fsm::start_in(End(()));
 }
 

--- a/tests/state_conversions.rs
+++ b/tests/state_conversions.rs
@@ -24,7 +24,6 @@ pub enum Fsm {
     End(()),
 }
 
-
 impl PollFsm for Fsm {
     fn poll_begin<'a>(_: &'a mut RentToOwn<'a, Begin>) -> Poll<AfterBegin, ()> {
         unimplemented!()
@@ -39,9 +38,7 @@ impl PollFsm for Fsm {
     }
 }
 
-fn convert<S: Into<FsmStates>>(_state: S) {
-
-}
+fn convert<S: Into<FsmStates>>(_state: S) {}
 
 #[test]
 fn convert_states() {

--- a/tests/take_context_on_error.rs
+++ b/tests/take_context_on_error.rs
@@ -8,8 +8,7 @@ use futures::Future;
 use futures::Poll;
 use state_machine_future::RentToOwn;
 
-pub struct Context {
-}
+pub struct Context {}
 
 #[derive(StateMachineFuture)]
 #[state_machine_future(context = "Context")]
@@ -37,7 +36,6 @@ impl PollWithContext for WithContext {
 
 #[test]
 fn given_sm_with_context_can_take_context_on_error() {
-
     let context = Context {};
 
     let mut machine = WithContext::start(context);

--- a/tests/take_context_on_ready.rs
+++ b/tests/take_context_on_ready.rs
@@ -9,8 +9,7 @@ use futures::Future;
 use futures::Poll;
 use state_machine_future::RentToOwn;
 
-pub struct Context {
-}
+pub struct Context {}
 
 #[derive(StateMachineFuture)]
 #[state_machine_future(context = "Context")]
@@ -38,7 +37,6 @@ impl PollWithContext for WithContext {
 
 #[test]
 fn given_sm_with_context_can_take_context_on_ready() {
-
     let context = Context {};
 
     let mut machine = WithContext::start(context);

--- a/tests/take_context_value_on_ready.rs
+++ b/tests/take_context_value_on_ready.rs
@@ -41,7 +41,6 @@ impl PollWithContext for WithContext {
 
 #[test]
 fn given_sm_with_context_can_take_context_value_on_ready() {
-
     let context = Context {
         value: String::from("foo"),
     };


### PR DESCRIPTION
Some of the formatting on files was out of date for the nightly
toolchain as described in CONTRIBUTING.md. This was making contribution
a little bit awkward as reformatting entire files would cause unwanted
changes.

Sorry this is a bit long but I assume these changes would happen eventually, and both the beta and stable formatters also produce a large number of changes.