### PR TITLE
Allow machine and contexts to have different type parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ without having to explicitly include it in every one.
 
 The context can be specified through the `context` argument of the `state_machine_future` attribute.
 This will add parameters to the `start` method as well as to each `poll_*` method of the trait.
+Note that if the context has type parameters, those type parameters must be declared in the
+context argument, along with any associated bounds.
 
 ```rust
 #[macro_use]
@@ -250,8 +252,8 @@ extern crate futures;
 use futures::*;
 use state_machine_future::*;
 
-struct MyContext {
-
+struct MyContext<T> where T: Clone {
+    data: T,
 }
 
 struct MyItem {
@@ -263,7 +265,7 @@ enum MyError {
 }
 
 #[derive(StateMachineFuture)]
-#[state_machine_future(context = "MyContext")]
+#[state_machine_future(context = "MyContext<T: Clone>")]
 enum MyStateMachine {
     #[state_machine_future(start, transitions(Intermediate))]
     Start,
@@ -279,9 +281,9 @@ enum MyStateMachine {
 }
 
 impl PollMyStateMachine for MyStateMachine {
-    fn poll_start<'s, 'c>(
+    fn poll_start<'s, 'c, T: Clone>(
         start: &'s mut RentToOwn<'s, Start>,
-        context: &'c mut RentToOwn<'c, MyContext>
+        context: &'c mut RentToOwn<'c, MyContext<T>>
     ) -> Poll<AfterStart, MyError> {
 
         // The `context` instance passed into `start` is available here.
@@ -290,9 +292,9 @@ impl PollMyStateMachine for MyStateMachine {
         unimplemented!()
     }
 
-    fn poll_intermediate<'s, 'c>(
+    fn poll_intermediate<'s, 'c, T: Clone>(
         intermediate: &'s mut RentToOwn<'s, Intermediate>,
-        context: &'c mut RentToOwn<'c, MyContext>
+        context: &'c mut RentToOwn<'c, MyContext<T>>
     ) -> Poll<AfterIntermediate, MyError> {
 
         // The `context` is available here as well.
@@ -304,7 +306,9 @@ impl PollMyStateMachine for MyStateMachine {
 }
 
 fn main() {
-    let _ = MyStateMachine::start(MyContext { });
+    let _ = MyStateMachine::start(MyContext {
+        data: "foo",
+    });
 }
 ```
 

--- a/src/compile_fail_tests.rs
+++ b/src/compile_fail_tests.rs
@@ -626,3 +626,24 @@ mod reachable_state_without_path_to_ready_or_error {
     ```
      */
 }
+
+mod unparseable_context_type {
+    /*!
+    ```compile_fail
+    #[macro_use]
+    extern crate state_machine_future;
+    extern crate futures;
+    use futures::*;
+    use std::fmt::Debug;
+
+    #[derive(StateMachineFuture)]
+    #[state_machine_future(context = "this isn't rust syntax")]
+    pub enum Machine {
+        #[state_machine_future(start)]
+        #[state_machine_future(ready)]
+        #[state_machine_future(error)]
+        OnlyState(()),
+    }
+    ```
+     */
+}

--- a/tests/call_to_context.rs
+++ b/tests/call_to_context.rs
@@ -29,7 +29,7 @@ impl<T: Clone + 'static> Context<T> {
 }
 
 #[derive(StateMachineFuture)]
-#[state_machine_future(context = "Context")]
+#[state_machine_future(context = "Context<T>")]
 pub enum WithContext<T: Clone + 'static> {
     #[state_machine_future(start, transitions(Ready))]
     Start(()),

--- a/tests/context_generic.rs
+++ b/tests/context_generic.rs
@@ -1,0 +1,42 @@
+//! Test using a generic context in a non-generic state machine.
+
+extern crate futures;
+#[macro_use]
+extern crate state_machine_future;
+
+use futures::Poll;
+use state_machine_future::RentToOwn;
+
+#[allow(dead_code)]
+pub struct Context<T> {
+    data: T,
+}
+
+#[derive(StateMachineFuture)]
+#[state_machine_future(context = "Context<T>")]
+pub enum WithContext {
+    #[state_machine_future(start, transitions(Ready))]
+    Start(),
+
+    #[state_machine_future(ready)]
+    Ready(()),
+
+    #[state_machine_future(error)]
+    Error(()),
+}
+
+impl PollWithContext for WithContext {
+    fn poll_start<'s, 'c, T>(
+        _: &'s mut RentToOwn<'s, Start>,
+        _: &'c mut RentToOwn<'c, Context<T>>,
+    ) -> Poll<AfterStart, ()> {
+        unimplemented!()
+    }
+}
+
+#[test]
+fn generic_sm_with_nongeneric_context() {
+    let context = Context { data: 42 };
+
+    let _ = WithContext::start(context);
+}

--- a/tests/context_generic_bounds.rs
+++ b/tests/context_generic_bounds.rs
@@ -1,0 +1,50 @@
+//! Test using a generic context with type bounds in a non-generic state
+//! machine.
+
+extern crate futures;
+#[macro_use]
+extern crate state_machine_future;
+
+use futures::Poll;
+use state_machine_future::RentToOwn;
+
+#[allow(dead_code)]
+pub struct Context<T, U, V: Send> where T: Clone {
+    data1: T,
+    data2: U,
+    data3: V,
+}
+
+#[derive(StateMachineFuture)]
+#[state_machine_future(context = "Context<T: Clone, U, V: Send>")]
+pub enum WithContext {
+    #[state_machine_future(start, transitions(Ready))]
+    Start(),
+
+    #[state_machine_future(ready)]
+    Ready(()),
+
+    #[state_machine_future(error)]
+    Error(()),
+}
+
+impl PollWithContext for WithContext {
+    fn poll_start<'s, 'c, T: Clone, U, V>(
+        _: &'s mut RentToOwn<'s, Start>,
+        context: &'c mut RentToOwn<'c, Context<T, U, V>>,
+    ) -> Poll<AfterStart, ()> where V: Send {
+        let _ = context.data1.clone();
+        transition!(Ready(()))
+    }
+}
+
+#[test]
+fn nongeneric_sm_with_generic_context_with_bounds() {
+    let context = Context {
+        data1: 1,
+        data2: "2",
+        data3: '3',
+    };
+
+    let _ = WithContext::start(context);
+}

--- a/tests/context_nongeneric.rs
+++ b/tests/context_nongeneric.rs
@@ -1,0 +1,39 @@
+//! Test using a non-generic context in a generic state machine.
+
+extern crate futures;
+#[macro_use]
+extern crate state_machine_future;
+
+use futures::Poll;
+use state_machine_future::RentToOwn;
+
+pub struct Context {}
+
+#[derive(StateMachineFuture)]
+#[state_machine_future(context = "Context")]
+pub enum WithContext<T> {
+    #[state_machine_future(start, transitions(Ready))]
+    Start(T),
+
+    #[state_machine_future(ready)]
+    Ready(()),
+
+    #[state_machine_future(error)]
+    Error(()),
+}
+
+impl<T> PollWithContext<T> for WithContext<T> {
+    fn poll_start<'s, 'c>(
+        _: &'s mut RentToOwn<'s, Start<T>>,
+        _: &'c mut RentToOwn<'c, Context>,
+    ) -> Poll<AfterStart, ()> {
+        unimplemented!()
+    }
+}
+
+#[test]
+fn generic_sm_with_nongeneric_context() {
+    let context = Context {};
+
+    let _ = WithContext::start((), context);
+}

--- a/tests/context_semigeneric.rs
+++ b/tests/context_semigeneric.rs
@@ -1,0 +1,44 @@
+//! Test using a generic context in a generic state machine where only
+//! some of the type parameters overlap.
+
+extern crate futures;
+#[macro_use]
+extern crate state_machine_future;
+
+use futures::{Future, Poll};
+use state_machine_future::RentToOwn;
+
+pub struct Context<T> {
+    data: T,
+}
+
+#[derive(StateMachineFuture)]
+#[state_machine_future(context = "Context<U>")]
+pub enum WithContext<T, U> {
+    #[state_machine_future(start, transitions(Ready))]
+    Start(T),
+
+    #[state_machine_future(ready)]
+    Ready(U),
+
+    #[state_machine_future(error)]
+    Error(()),
+}
+
+impl<T, U> PollWithContext<T, U> for WithContext<T, U> {
+    fn poll_start<'s, 'c>(
+        _: &'s mut RentToOwn<'s, Start<T>>,
+        context: &'c mut RentToOwn<'c, Context<U>>,
+    ) -> Poll<AfterStart<U>, ()> {
+        transition!(Ready(context.take().data));
+    }
+}
+
+#[test]
+fn generic_sm_with_semigeneric_context() {
+    let context = Context {
+        data: 42,
+    };
+
+    assert_eq!(WithContext::start((), context).wait(), Ok(42));
+}


### PR DESCRIPTION
The code generation presently assumes that the state machine and its
context, if present, will share the same type parameters. This works
fine in the common case where neither the machine nor the context have
any type parameters, but breaks down when, say, the state machine has
type parameters but the context does not.

Require that the #[state_machine_future(context = ...)] annotation
specify explicitly what type parameters exist on the context, and with
what bounds. This allows code generation to propagate the type
parameters correctly. For example, if only the context has type
parameter T, the generated future must be generic over T, even though
the state machine enum will not be.

Note that this is a breaking change for state machines where the machine
and the context have exactly the same type parameters--for an example of
this, see the call_to_context test--as the context annotation will need
to be updated to specify the type parameter. I don't see a solution that
avoids this, unfortunately, but on the bright side the common case where
no type parameters are used is unaffected.