### PR TITLE
sed s/proc_macro/proc-macro/g **/Cargo.toml

### DIFF
--- a/derive_state_machine_future/Cargo.toml
+++ b/derive_state_machine_future/Cargo.toml
@@ -28,4 +28,4 @@ debug_code_generation = []
 
 [lib]
 path = "./src/lib.rs"
-proc_macro = true
+proc-macro = true


### PR DESCRIPTION
Cargo seems to accept both variants, but `proc-macro = true` is the documented variant. However, some external tools (such as [Carnix](https://nest.pijul.com/pmeunier/carnix:master)) only tolerate `proc-macro`, and silently ignore `proc_macro` (causing build failures).