### PR TITLE
Remove RentToOwn

### DIFF
--- a/derive_state_machine_future/src/ast.rs
+++ b/derive_state_machine_future/src/ast.rs
@@ -1,8 +1,8 @@
 //! AST types for state machines and their states.
 
 use darling;
-use phases;
 use syn;
+use super::phases;
 
 /// A description of a state machine: its various states, which is the start
 /// state, ready state, and error state.
@@ -187,3 +187,4 @@ impl State<phases::NoPhase> {
         }
     }
 }
+

--- a/derive_state_machine_future/src/phases.rs
+++ b/derive_state_machine_future/src/phases.rs
@@ -847,9 +847,7 @@ impl Pass for ReadyForCodegen {
             future_trait += &machine_name;
             let future_trait = Rc::new(Ident::new(&future_trait, Span::call_site()));
 
-            let mut smf_crate = String::from("__smf_");
-            smf_crate += machine_name.clone().to_snake_case().as_str();
-            smf_crate += "_state_machine_future";
+            let mut smf_crate = String::from("state_machine_future");
             let smf_crate = Rc::new(Ident::new(&smf_crate, Span::call_site()));
 
             let states = states

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -594,13 +594,15 @@ pub trait StateMachineFuture {
     type Future: futures::Future;
 }
 
-/// Type returned by poll methods
+/// Async type similar to future's Async. The NotReady variant provides a type
+/// parameter to return object ownership to StateMachineFuture implementation
 #[derive(Debug)]
-pub enum SMPoll<R, NR, E> {
+pub enum SMAsync<R, NR> {
     /// The poll method is transtionning to another state
     Ready(R),
     /// The poll method is not ready yet
     NotReady(NR),
-    /// An error happened
-    Error(E),
 }
+
+/// Type returned by poll methods
+pub type SMPoll<R, NR, E> = Result<SMAsync<R, NR>, E>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -581,6 +581,7 @@ mod transition;
 #[doc(hidden)]
 pub mod export {
     pub use futures::{Async, Future, Poll};
+    pub use std::mem::replace;
 }
 
 /// Re-export of `rent_to_own::RentToOwn`.
@@ -591,4 +592,15 @@ pub type RentToOwn<'a, T> = rent_to_own::RentToOwn<'a, T>;
 pub trait StateMachineFuture {
     /// The generated `Future` type for this state machine.
     type Future: futures::Future;
+}
+
+/// Type returned by poll methods
+#[derive(Debug)]
+pub enum SMPoll<R, NR, E> {
+    /// The poll method is transtionning to another state
+    Ready(R),
+    /// The poll method is not ready yet
+    NotReady(NR),
+    /// An error happened
+    Error(E),
 }

--- a/src/transition.rs
+++ b/src/transition.rs
@@ -2,7 +2,7 @@
 #[macro_export]
 macro_rules! transition {
     ( $new_state:expr ) => {
-        return ::state_machine_future::SMPoll::Ready($new_state);
+        return Ok(::state_machine_future::SMAsync::Ready($new_state));
     };
 }
 
@@ -10,14 +10,6 @@ macro_rules! transition {
 #[macro_export]
 macro_rules! not_ready {
     ( $new_state:expr ) => {
-        return ::state_machine_future::SMPoll::NotReady($new_state);
-    };
-}
-
-/// Auxiliary macro for `poll_state_xy` functions to return error
-#[macro_export]
-macro_rules! error {
-    ( $new_state:expr ) => {
-        return ::state_machine_future::SMPoll::Error($new_state);
+        return Ok(::state_machine_future::SMAsync::NotReady($new_state));
     };
 }

--- a/src/transition.rs
+++ b/src/transition.rs
@@ -2,6 +2,22 @@
 #[macro_export]
 macro_rules! transition {
     ( $new_state:expr ) => {
-        return Ok(::futures::Async::Ready($new_state.into()));
+        return ::state_machine_future::SMPoll::Ready($new_state);
+    };
+}
+
+/// Auxiliary macro for `poll_state_xy` functions to declare not ready
+#[macro_export]
+macro_rules! not_ready {
+    ( $new_state:expr ) => {
+        return ::state_machine_future::SMPoll::NotReady($new_state);
+    };
+}
+
+/// Auxiliary macro for `poll_state_xy` functions to return error
+#[macro_export]
+macro_rules! error {
+    ( $new_state:expr ) => {
+        return ::state_machine_future::SMPoll::Error($new_state);
     };
 }

--- a/tests/futures.rs
+++ b/tests/futures.rs
@@ -1,0 +1,51 @@
+#[macro_use] extern crate state_machine_future;
+extern crate futures;
+
+#[derive(Debug, PartialEq, Eq)]
+struct MyItem;
+#[derive(Debug, PartialEq, Eq)]
+enum MyError {
+}
+
+#[derive(StateMachineFuture)]
+enum MyStateMachine {
+    #[state_machine_future(start, transitions(Counter))]
+    Start,
+
+    #[state_machine_future(transitions(Ready))]
+    Counter(usize),
+
+    #[state_machine_future(ready)]
+    Ready(MyItem),
+
+    #[state_machine_future(error)]
+    Error(MyError),
+}
+
+impl FutureMyStateMachine for MyStateMachine {
+    fn poll_start(_start: Start) -> SMPoll<AfterStart, Start, MyError> {
+        transition!(AfterStart::Counter(Counter(3)))
+    }
+    fn poll_counter(counter: Counter) -> SMPoll<AfterCounter, Counter, MyError> {
+        let value = counter.0;
+
+        if value == 0 {
+            transition!(AfterCounter::Ready(Ready(MyItem)))
+        } else {
+            not_ready!(Counter(value - 1))
+        }
+    }
+}
+
+use futures::Async;
+use futures::future::Future;
+
+#[test]
+fn test_state_machine() {
+    let mut sm = MyStateMachine::start();
+
+    assert_eq!(sm.poll(), Ok(Async::NotReady));
+    assert_eq!(sm.poll(), Ok(Async::NotReady));
+    assert_eq!(sm.poll(), Ok(Async::NotReady));
+    assert_eq!(sm.poll(), Ok(Async::Ready(MyItem)));
+}


### PR DESCRIPTION
Hello!

Well, first, thanks for making `state_machine_future`. It's great and I like the design of it a lot!

This Pull request changes the api to remove the renttoown behavior. Why? See https://github.com/fitzgen/state_machine_future/pull/49#issuecomment-510561659

The purpose is to come with an api which I find easier and does not have undefined behavior:
```rust
#[macro_use] extern crate state_machine_future;
extern crate futures;

#[derive(Debug, PartialEq, Eq)]
struct MyItem;
#[derive(Debug, PartialEq, Eq)]
enum MyError {
}

#[derive(StateMachineFuture)]
enum MyStateMachine {
    #[state_machine_future(start, transitions(Counter))]
    Start,

    #[state_machine_future(transitions(Ready))]
    Counter(usize),

    #[state_machine_future(ready)]
    Ready(MyItem),

    #[state_machine_future(error)]
    Error(MyError),
}

impl FutureMyStateMachine for MyStateMachine {
    fn poll_start(_start: Start) -> SMPoll<AfterStart, Start, MyError> {
        transition!(AfterStart::Counter(Counter(3)))
    }
    fn poll_counter(counter: Counter) -> SMPoll<AfterCounter, Counter, MyError> {
        let value = counter.0;

        if value == 0 {
            transition!(AfterCounter::Ready(Ready(MyItem)))
        } else {
            not_ready!(Counter(value - 1))
        }
    }
}

use futures::Async;
use futures::future::Future;

#[test]
fn test_state_machine() {
    let mut sm = MyStateMachine::start();

    assert_eq!(sm.poll(), Ok(Async::NotReady));
    assert_eq!(sm.poll(), Ok(Async::NotReady));
    assert_eq!(sm.poll(), Ok(Async::NotReady));
    assert_eq!(sm.poll(), Ok(Async::Ready(MyItem)));
}
```

I also have another branch with an implementation for streams (not commited here):
``` rust
#[macro_use] extern crate state_machine_future;

#[derive(Debug, PartialEq, Eq)]
struct MyItem;
#[derive(Debug, PartialEq, Eq)]
enum MyError {
}

#[derive(StateMachineStream)]
#[state_machine_stream(item = "MyItem")]
enum MyStateMachine {
    #[state_machine_stream(start, transitions(Connect))]
    Start,

    #[state_machine_stream(transitions(Connect))]
    Retry(usize),

    #[state_machine_stream(transitions(ConsumeBody, Retry))]
    Connect(usize),

    #[state_machine_stream(yields, transitions(Complete, Connect))]
    ConsumeBody(usize),

    #[state_machine_stream(eof)]
    Complete,

    #[state_machine_stream(error)]
    Error(MyError),
}

impl StreamMyStateMachine for MyStateMachine {
    fn poll_start(_start: Start) -> SMFPoll<AfterStart, Start, MyError> {
        transition!(AfterStart::Connect(Connect(16)))
    }

    fn poll_connect(connect: Connect) -> SMFPoll<AfterConnect, Connect, MyError> {
        println!("connect {}", connect.0);
        match connect.0 {
            v if v % 4 == 0 => not_ready!(Connect(v - 1)),
            v if v % 8 == 3 => transition!(AfterConnect::ConsumeBody(ConsumeBody(v - 1))),
            v if v % 8 == 7 => transition!(AfterConnect::Retry(Retry(v - 1))),
            _ => unreachable!("bug?"),
        }
    }

    fn poll_retry(retry: Retry) -> SMFPoll<AfterRetry, Retry, MyError> {
        println!("retry {}", retry.0);
        match retry.0 {
            v if v % 8 == 5 => transition!(AfterRetry::Connect(Connect(v - 1))),
            v if v % 8 == 6 => not_ready!(Retry(v - 1)),
            _ => unreachable!("bug?"),
        }
    }

    // enum AfterConsumeBody {
    //     Connect(MyItem, Connect),
    //     Complete,
    // }

    fn poll_consume_body(consume_body: ConsumeBody) -> SMFPoll<AfterConsumeBody, ConsumeBody, MyError> {
        println!("consume_body {}", consume_body.0);
        match consume_body.0 {
            1 => transition!(AfterConsumeBody::Complete),
            v if v % 8 == 1 => transition!(AfterConsumeBody::Connect(MyItem, Connect(v - 1))),
            v if v % 8 == 2 => not_ready!(ConsumeBody(v - 1)),
            _ => unreachable!("bug?"),
        }
    }

}

use futures::Async;
use futures::stream::Stream;

#[test]
fn test_state_machine() {
    let mut sm = MyStateMachine::start();

    assert_eq!(sm.poll(), Ok(Async::NotReady)); // -> 15
    assert_eq!(sm.poll(), Ok(Async::NotReady)); // -> 13
    assert_eq!(sm.poll(), Ok(Async::NotReady)); // -> 11
    assert_eq!(sm.poll(), Ok(Async::NotReady)); // -> 9
    assert_eq!(sm.poll(), Ok(Async::Ready(Some(MyItem)))); // -> 8

    assert_eq!(sm.poll(), Ok(Async::NotReady)); // -> 7
    assert_eq!(sm.poll(), Ok(Async::NotReady)); // -> 5
    assert_eq!(sm.poll(), Ok(Async::NotReady)); // -> 3
    assert_eq!(sm.poll(), Ok(Async::NotReady)); // -> 1
    assert_eq!(sm.poll(), Ok(Async::Ready(None)));
    assert_eq!(sm.poll(), Ok(Async::Ready(None)));
}
```

The purpose of opening this pull request is to check whether you would be open to a change in the api like this or not :)

Thanks!